### PR TITLE
Deleted blank first line.

### DIFF
--- a/lib/php-jwt/run-tests.sh
+++ b/lib/php-jwt/run-tests.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 gpg --fingerprint D8406D0D82947747293778314AA394086372C20A
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Shebang only has an effect when it appears as the first line in a script.